### PR TITLE
Support for non-hourly offset timezones - refs issues 55 and 76

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -121,7 +121,7 @@ class CronExpression
     {
         if (!$this->fieldFactory->getField($position)->validate($value)) {
             throw new \InvalidArgumentException(
-                'Invalid CRON field value ' . $value . ' as position ' . $position
+                'Invalid CRON field value ' . $value . ' at position ' . $position
             );
         }
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -73,6 +73,25 @@ class CronExpression
     }
 
     /**
+     * Validate a CronExpression.
+     *
+     * @param string $expression The CRON expression to validate.
+     *
+     * @return bool True if a valid CRON expression was passed. False if not.
+     * @see Cron\CronExpression::factory
+     */
+    public static function isValidExpression($expression = '')
+    {
+        try {
+            self::factory($expression);
+        } catch (\InvalidArgumentException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Parse a CRON expression
      *
      * @param string       $expression   CRON expression (e.g. '8 * * * *')

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -80,7 +80,7 @@ class CronExpression
      * @return bool True if a valid CRON expression was passed. False if not.
      * @see Cron\CronExpression::factory
      */
-    public static function isValidExpression($expression = '')
+    public static function isValidExpression($expression)
     {
         try {
             self::factory($expression);

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -373,4 +373,19 @@ class CronExpressionTest extends \PHPUnit_Framework_TestCase
         $cron->getPreviousRunDate($now);
         $this->assertEquals($strNow, $now->format(\DateTime::ISO8601));
     }
+
+    /**
+     * @covers Cron\CronExpression::__construct
+     * @covers Cron\CronExpression::factory
+     * @covers Cron\CronExpression::isValidExpression
+     * @covers Cron\CronExpression::setExpression
+     * @covers Cron\CronExpression::setPart
+     */
+    public function testValidationWorks()
+    {
+        // Invalid. Only four values
+        $this->assertFalse(CronExpression::isValidExpression('* * * 1'));
+        // Valid
+        $this->assertTrue(CronExpression::isValidExpression('* * * * 1'));
+    }
 }


### PR DESCRIPTION
Great package!

Our project has a requirement to support non-hourly offset timezones ('America/St_Johns' for example) and a colleague of mine has created a fork which resolves the "Impossible CronExpression" issue when using these timezones.

This PR should help resolve:
https://github.com/mtdowling/cron-expression/issues/55
https://github.com/mtdowling/cron-expression/issues/76

Thanks,
Alan
